### PR TITLE
remove kinetic dependencies

### DIFF
--- a/fake_joint_launch/package.xml
+++ b/fake_joint_launch/package.xml
@@ -20,12 +20,9 @@
 
   <exec_depend>abb_irb2400_support</exec_depend>
   <exec_depend>controller_manager</exec_depend>
-  <exec_depend>denso_ros_control</exec_depend>
-  <exec_depend>nextage_description</exec_depend>
   <exec_depend>pr2_description</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>rviz</exec_depend>
-  <exec_depend>tra1_description</exec_depend>
   <exec_depend>ur_description</exec_depend>
 
   <export></export>


### PR DESCRIPTION
this removes dependencies that are not published for melodic so rosdep will work